### PR TITLE
INTing the mongo port

### DIFF
--- a/src/cfpb/qu/data.clj
+++ b/src/cfpb/qu/data.clj
@@ -12,7 +12,7 @@ after retrieval."
              json]))
 
 (defn connect-mongo []
-  (let [address (mongo/server-address (env :mongo-host) (env :mongo-port))
+  (let [address (mongo/server-address (env :mongo-host)  (Integer/parseInt(str (env :mongo-port))))
         options (mongo/mongo-options)]
     (mongo/connect! address options)))
 


### PR DESCRIPTION
Ensuring that the mongo port is passed through as an int. This is necessary when setting java system properties via -D are created as strings, such as by an IDE (IntelliJ in this case)
