### PR TITLE
Add midje-junit-formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /classes
 /checkouts
 pom.xml
+report.xml
 *.jar
 *.class
 .DS_Store

--- a/.midje-junitxml.clj
+++ b/.midje-junitxml.clj
@@ -1,0 +1,2 @@
+(change-defaults :emitter 'midje-junit-formatter.core
+                 :print-level :print-facts)

--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,8 @@ serve their public data sets."
                     :mongo-port 27017}
               :embongo {:version "2.4.3"}
               :dependencies [[ring-mock "0.1.3"]
-                             [midje "1.6-SNAPSHOT"]]}
+                             [midje "1.6-SNAPSHOT"]
+                             [midje-junit-formatter "0.1.0-SNAPSHOT"]]}
              :integration [:dev
               {:env {:mongo-port 37017
                      :integration true}


### PR DESCRIPTION
This adds the dependency on the midje-junit-formatter library as well as a config file to be used during builds via `lein midje :config .midje.clj .midje-junitxml.clj`
