### PR TITLE
Add ability to query COUNT() without specifying a column

### DIFF
--- a/src/cfpb/qu/query/parser.clj
+++ b/src/cfpb/qu/query/parser.clj
@@ -19,7 +19,7 @@
 (defn- ci-string
   "Match case insensitive strings."
   [string]
-  (regex (re-pattern (str "(?i)" string))))
+  (regex (re-pattern (str "(?i)\\Q" string "\\E"))))
 
 (defn- string-literal []
   (any dq-str sq-str))
@@ -148,6 +148,11 @@ turn it into a tree built in proper precedence order."
                  #(ci-string "MIN"))]
     (keyword (str/upper-case agg))))
 
+(defn- count-select []
+  (let [_ (ci-string "COUNT()")]
+    {:aggregation [:COUNT :_id]
+     :select :count}))
+
 (defn- aggregation-select
   []
   (let [aggregation (aggregation)
@@ -161,6 +166,7 @@ turn it into a tree built in proper precedence order."
 (defn- select
   []
   (any aggregation-select
+       count-select
        simple-select))
 
 (defn select-expr

--- a/src/cfpb/qu/query/validation.clj
+++ b/src/cfpb/qu/query/validation.clj
@@ -15,8 +15,9 @@
 
 (defn valid-field? [{:keys [metadata slice]} field]
   (let [fields (->> (slice-columns (get-in metadata [:slices (keyword slice)]))
-                     (map name)
-                     set)]
+                     (map name)                     
+                     set)
+        fields (conj fields "_id")]
     (contains? fields field)))
 
 (defn- add-error

--- a/test/cfpb/qu/query/parser_test.clj
+++ b/test/cfpb/qu/query/parser_test.clj
@@ -117,6 +117,17 @@
               {:aggregation [:SUM :population]
                :select :sum_population}])
 
+       (fact "COUNT aggregations do not need an identifier"
+             (p/parse select-expr "state, COUNT()") =>
+             [{:select :state}
+              {:aggregation [:COUNT :_id]
+               :select :count}]
+
+             (p/parse select-expr "state, count()") =>
+             [{:select :state}
+              {:aggregation [:COUNT :_id]
+               :select :count}])
+
        (fact "aggregations are case-insensitive"
              (p/parse select-expr "state, sum(population)") =>
              [{:select :state}


### PR DESCRIPTION
Getting a row count doesn't use the column anyway, so now
you can aggregate with COUNT() alone. COUNT(whatever) still
works, but COUNT() is preferred.
