### PR TITLE
Upgrade some core packages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,10 +22,9 @@ serve their public data sets."
   :aot [cfpb.qu.main]
   :repl-options {:init-ns user}
   :plugins [[lein-environ "0.4.0"]
-            [lein-midje "3.0.0"]
+            [lein-midje "3.1.1"]
             [lein-embongo "0.2.1"]
-            [configleaf "0.4.6"]]
-  :hooks [configleaf.hooks]  
+            [slothcfg "1.0.1"]]
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [cheshire "5.2.0"]
                  [clj-statsd "0.3.9"]                 
@@ -33,21 +32,21 @@ serve their public data sets."
                  [clojurewerkz/urly "1.0.0"]
                  [com.novemberain/monger "1.6.0"]
                  [com.stuartsierra/dependency "0.1.1"]                 
-                 [com.taoensso/timbre "2.4.1"]
+                 [com.taoensso/timbre "2.5.0"]
                  [compojure "1.1.5"]
                  [digest "1.4.3"]
                  [environ "0.4.0"]
                  [factual/drake "0.1.4-SNAPSHOT"]
                  [halresource "0.1.1-SNAPSHOT"]
-                 [http-kit "2.1.5"]                 
-                 [lib-noir "0.6.6"]
+                 [http-kit "2.1.9"]                 
+                 [lib-noir "0.6.8"]
                  [liberator "0.9.0"]
                  [lonocloud/synthread "1.0.5"]
                  [org.clojure/data.csv "0.1.2"]
                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]                 
                  [parse-ez "0.3.6"]
+                 [ring "1.2.0"]                 
                  [ring.middleware.mime-extensions "0.2.0"]
-                 [ring/ring-core "1.1.6"]
                  [stencil "0.3.2"]
                  ]
   :env {:mongo-host "127.0.0.1"
@@ -60,14 +59,14 @@ serve their public data sets."
   :jar-exclusions [#"(^|/)\." #"datasets/.*" ]
   :uberjar-exclusions [#"(^|/)\." #"datasets/.*"
                        #"META-INF/.*\.SF" #"META-INF/.*\.[RD]SA"]  
-  :configleaf {:namespace cfpb.qu.project
-               :config-source-path "src"}
+  :slothcfg {:namespace cfpb.qu.project
+             :config-source-path "src"}
   :profiles {:dev {:source-paths ["dev"]
                    :env {:dev true}
                    :embongo {:version "2.4.5"}
                    :dependencies [[alembic "0.1.3"]
-                                  [clj-http "0.7.2"]                                  
-                                  [midje "1.6-alpha2"]
+                                  [clj-http "0.7.6"]   
+                                  [midje "1.6-SNAPSHOT"]
                                   [midje-junit-formatter "0.1.0-SNAPSHOT"]
                                   [org.clojure/tools.namespace "0.2.4"]
                                   [org.clojure/java.classpath "0.2.1"]


### PR DESCRIPTION
Specifically, move from configleaf to its fork, slothcfg, as configleaf breaks under Leiningen 2.3.

This also fixes the Midje Junit XML issue.
