### PR TITLE
Preaggregations can include medians now

### DIFF
--- a/resources/datasets/integration_test/definition.json
+++ b/resources/datasets/integration_test/definition.json
@@ -54,11 +54,13 @@
       ],
       "metrics": [
         "counties",
-        "tax_returns"
+        "tax_returns",
+        "median_tax_return"
       ],
       "aggregations": {
         "counties": ["count"],
-        "tax_returns": ["sum", "tax_returns"]
+        "tax_returns": ["sum", "tax_returns"],
+        "median_tax_return": ["median", "tax_returns"]
       }
     }
   },  

--- a/resources/datasets/integration_test/test_data.csv
+++ b/resources/datasets/integration_test/test_data.csv
@@ -14,3 +14,5 @@ County Code,State Abbreviation,County Name,Total Number of Tax Returns,Adjusted 
 13,NY,County 13,13,1300,2013/01/13
 14,NY,County 14,14,1400,2013/01/14
 15,NY,County 15,15,1500,2013/01/15
+16,DC,County 16,16,1600,2013/01/16
+17,DC,County 17,17,1700,2013/01/17

--- a/test/integration/loader_test.clj
+++ b/test/integration/loader_test.clj
@@ -21,4 +21,13 @@
                      result (data/get-find db coll query)]
                  (doseq [datum (:data result)]
                    (class (:date_observed datum)) =>
-                   org.joda.time.DateTime)))))
+                   org.joda.time.DateTime))))
+
+  (facts "about median pre-aggregations"
+         (fact "they work!"
+               (let [query {:query {} :fields {} :limit 100 :skip 0 :sort {}}
+                     result (data/get-find db "incomes_by_state" query)
+                     medians (->> result
+                                  :data
+                                  (map :median_tax_return))]
+                 medians => (just [3.0 7.0 13.0 16.5] :in-any-order)))))

--- a/test/integration/mongo_query_test.clj
+++ b/test/integration/mongo_query_test.clj
@@ -44,12 +44,11 @@
 
   ;; get-find and get-aggregation facts are simply sanity checks
   (facts "about get-find"
-
     (fact "returns a QueryResult object with total, size, and data (Seq of maps)"
-      (let [ limit 2
-             query {:query {} :fields {} :limit limit :skip 0 :sort {}}
-             result (data/get-find db coll query)]
-        (> (:total result) limit ) => true
+      (let [limit 2
+            query {:query {} :fields {} :limit limit :skip 0 :sort {}}
+            result (data/get-find db coll query)]
+        (> (:total result) limit) => true
         (:size result) => limit
         (count (:data result)) => limit)))
 
@@ -61,10 +60,10 @@
                    {"$sort" {:state_abbr 1}}]
             result (data/get-aggregation db coll query)]
         ;; We know the integration_test dataset has 3 states
-        (map :state_abbr (:data result)) => ["NC" "NY" "PA"]
-        (:total result) => 3
-        (:size result) => 3
-        (count (:data result)) => 3)))
+        (map :state_abbr (:data result)) => (just ["NC" "NY" "PA" "DC"] :in-any-order)
+        (:total result) => 4
+        (:size result) => 4
+        (count (:data result)) => 4)))
 
   (facts "about execute"
 
@@ -121,12 +120,13 @@
       (let [q (params->Query {:$select "state_abbr, SUM(tax_returns), COUNT(tax_returns), MIN(tax_returns), MAX(tax_returns)", :$group "state_abbr", :$orderBy "state_abbr"} metadata :incomes)
             result (query/execute db coll q)
             query_result (:result result)]
-        (:size query_result) => 3
-        (:total query_result) => 3
-        (count (:data query_result)) => 3
-        (:data query_result) => [{:sum_tax_returns 15, :count_tax_returns 5, :min_tax_returns 1, :max_tax_returns 5, :state_abbr "NC"},
-                                 {:sum_tax_returns 65, :count_tax_returns 5, :min_tax_returns 11, :max_tax_returns 15, :state_abbr "NY"},
-                                 {:sum_tax_returns 40, :count_tax_returns 5, :min_tax_returns 6, :max_tax_returns 10, :state_abbr "PA"}])))
+        (:size query_result) => 4
+        (:total query_result) => 4
+        (count (:data query_result)) => 4
+        (:data query_result) => (just [{:sum_tax_returns 15, :count_tax_returns 5, :min_tax_returns 1, :max_tax_returns 5, :state_abbr "NC"},
+                                       {:sum_tax_returns 65, :count_tax_returns 5, :min_tax_returns 11, :max_tax_returns 15, :state_abbr "NY"},
+                                       {:sum_tax_returns 40, :count_tax_returns 5, :min_tax_returns 6, :max_tax_returns 10, :state_abbr "PA"},
+                                       {:sum_tax_returns 33, :count_tax_returns 2, :min_tax_returns 16, :max_tax_returns 17, :state_abbr "DC"}] :in-any-order))))
 
   (facts "about execute and error handling"
 


### PR DESCRIPTION
Because of limitations in MongoDB, medians cannot be done with normal
aggregations, but can be included in all preaggregated data.
