### PR TITLE
Change license to CC0

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -1,24 +1,5 @@
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org/>
+As a work of the United States Government, this package is in the
+public domain within the United States. Additionally, we waive
+copyright and related rights in the work worldwide through the CC0 1.0
+Universal public domain dedication (which can be found at 
+<http://creativecommons.org/publicdomain/zero/1.0/>).


### PR DESCRIPTION
Prompted by licensing talk during a GitHub for Government webinar I attended today, I wanted to open this Pull Request to discuss potentially changing our license to [CC0](http://creativecommons.org/publicdomain/zero/1.0/) (outside of the United States, where it is automatically in the public domain).

An extensive (but still ongoing) discussion about what license is most appropriate for government open source software is happening at the White House's [Project Open Data](https://github.com/project-open-data/project-open-data.github.io/pull/135#issuecomment-23299819). As of right now, a consensus seems to be forming around using CC0, as it is provides a bit more legal coverage than the [Unlicense](http://unlicense.org/). That is what this PR implements (for now).

At the suggestion of [this opendata.stackexchange.com answer](http://opendata.stackexchange.com/a/1050), the language is borrowed from HHS's [ckanext-datajson project](https://github.com/HHS/ckanext-datajson#credit--copying). It seems simple and clear, and doesn't inundate this file with the full text of the CC0 license. (I do think it might be worth putting in the human-readable summary of CC0, though.)

The `CONTRIBUTING.md` document may warrant a few tweaks, if this change is accepted, as well.

Thoughts?

@cndreisbach @marcesher @contolini @Burton
