### PR TITLE
Fixed derived slices so they work again

### DIFF
--- a/resources/datasets/hmda/definition.json
+++ b/resources/datasets/hmda/definition.json
@@ -626,6 +626,23 @@
         }
       }
     },
+    "census_tracts": {
+      "info": {
+        "name": "Census Tracts",
+        "description": "Distinct collection of Census Tracts for MSAMD and State Code, derived from the HMDA LAR data"
+      },
+      "type": "derived",
+      "slice": "hmda_lar",
+      "dimensions": [
+        "state_code", 
+        "msamd", 
+        "census_tract_number"
+      ],
+      "metrics": ["census_tracts"],
+      "aggregations": {
+        "census_tracts": ["count"]
+      }
+    },
     "application_groups": {
       "info": {
         "name": "HMDA Loan Application Records Grouped",

--- a/src/cfpb/qu/data/aggregation.clj
+++ b/src/cfpb/qu/data/aggregation.clj
@@ -34,8 +34,7 @@ within Mongo."
                (var vals (.map ary (fn [obj] (return (aget obj field)))))
                (return (.sum Array vals))))
    :count (js* (fn [ary field]
-                 (var vals (.map ary (fn [obj] (return (aget obj field)))))
-                 (return (.sum Array vals))))})
+                 (return (aget ary "length"))))})
 
 (defn- generate-map-fn
   ([group-fields agg-fields]

--- a/src/cfpb/qu/loader.clj
+++ b/src/cfpb/qu/loader.clj
@@ -269,6 +269,7 @@ transform that data into the form we want."
         dataset (:database definition)
 
         from-collection (:slice sdef)
+        from-slicedef (get-in definition [:slices (keyword from-collection)])
         to-collection slice
         to-zip-fn (field-zip-fn sdef)
 
@@ -286,7 +287,7 @@ transform that data into the form we want."
                                          :group dimensions
                                          :aggregations aggregations
                                          :filter filter
-                                         :slicedef sdef})
+                                         :slicedef from-slicedef})
 
         finalize-reduce-fn (fn [obj-name fields]
                              (reduce (fn [acc field]


### PR DESCRIPTION
The key compression interacted poorly with moving derived slices to using the map-reduce framework. I located the bug and fixed it.
