### PR TITLE
Added IN to WHERE query operators

### DIFF
--- a/src/cfpb/qu/query/parser.clj
+++ b/src/cfpb/qu/query/parser.clj
@@ -9,7 +9,7 @@
             any attempt multi* series
             number dq-str sq-str
             chr chr-in
-            parens sep-by
+            parens sep-by sep-by*
             word word-in
             string string-in
             regex starts-with?]]))
@@ -48,6 +48,12 @@ numeric expressions, strings, and booleans."
   []
   (any date-literal number string-literal boolean-literal))
 
+(defn list-of-values
+  []
+  (let [_ (chr \()
+        values (sep-by* value #(chr \,) #(chr \)))]
+    values))
+
 (defn- comparison-operator []
   (let [op (string-in [">" ">=" "=" "!=" "<" "<=" "LIKE" "ILIKE"])]
     (keyword op)))
@@ -75,12 +81,19 @@ underscores."
         is-null (ci-string "IS NOT NULL")]
     {:comparison [identifier :!= nil]}))
 
+(defn- comparison-in []
+  (let [identifier (identifier)
+        _ (ci-string "IN")
+        values (list-of-values)]
+    {:comparison [identifier :IN values]}))
+
 (defn comparison
   "Parse function for comparisons in WHERE queries. Comparisons are
 made up of an identifier and then either a comparison operator and a
 value or the phrases 'IS NULL' or 'IS NOT NULL'."
   []
   (any comparison-normal
+       comparison-in
        comparison-null
        comparison-not-null))
 

--- a/src/cfpb/qu/query/where.clj
+++ b/src/cfpb/qu/query/where.clj
@@ -18,6 +18,7 @@ for use in constructing Mongo queries."
 (def mongo-operators
   {:AND "$and"
    :OR "$or"
+   :IN "$in"
    :< "$lt"
    :<= "$lte"
    :> "$gt"

--- a/test/cfpb/qu/query/parser_test.clj
+++ b/test/cfpb/qu/query/parser_test.clj
@@ -30,6 +30,7 @@
        (fact "identifiers must start with a letter"
              (p/parse identifier "3times") => (throws Exception #"^Parse Error")))
 
+
 (facts "about comparisons"
        (fact "simple comparisons can be parsed"
              (p/parse comparison "length > 3") => {:comparison [:length :> 3]}
@@ -49,6 +50,10 @@
              
              (p/parse comparison "name ILIKE 'mar%'") =>
              {:comparison [:name :ILIKE "mar%"]})
+
+       (fact "IN comparisons can be parsed"
+             (p/parse comparison "length IN (1, 2, 3)") =>
+             {:comparison [:length :IN [1 2 3]]})
 
        (fact "spaces are irrelevant"
              (p/parse comparison "length>3") => {:comparison [:length :> 3]}))

--- a/test/cfpb/qu/query/where_test.clj
+++ b/test/cfpb/qu/query/where_test.clj
@@ -103,6 +103,10 @@
                       {"$or" [{:height {"$lt" 4.5}}
                               {:name "Pete"}]}]})
 
+       (fact "handles IN comparisons"
+             (mongo-eval (parse "name IN (\"Pete\", \"Sam\")")) =>
+             {:name {"$in" ["Pete" "Sam"]}})
+
        (fact "handles simple comparisons with NOT"
              (mongo-eval (parse "NOT name = \"Pete\"")) =>
              {:name {"$ne" "Pete"}}


### PR DESCRIPTION
You can now use IN to select one or more values that a field can be
equal to, like so:

  dividend_income IN (10173, 9033, 11902)
