### PR TITLE
Hide error messages in production

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,8 @@ serve their public data sets."
                        #"META-INF/.*\.SF" #"META-INF/.*\.[RD]SA"]  
   :slothcfg {:namespace cfpb.qu.project
              :config-source-path "src"}
-  :profiles {:uberjar {:aot [cfpb.qu.main]}
+  :profiles {:uberjar {:aot [cfpb.qu.main]
+                       :env {:dev false}}
              :dev {:source-paths ["dev"]
                    :env {:dev true}
                    :embongo {:version "2.4.5"}

--- a/resources/templates/500.mustache
+++ b/resources/templates/500.mustache
@@ -1,0 +1,5 @@
+<h1>Server Error</h1>
+
+<div class="message">
+  The server has had an unexpected error. The site administrators have been alerted.
+</div>    

--- a/src/cfpb/qu/env.clj
+++ b/src/cfpb/qu/env.clj
@@ -6,6 +6,8 @@
 (def default-env
   {:mongo-host "127.0.0.1"
    :mongo-port 27017
+   :mongo-options {:connect-timeout 2000
+                   :socket-timeout 2000}
    :statsd-port 8125
    :http-ip "127.0.0.1"
    :http-port 3000

--- a/src/cfpb/qu/logging.clj
+++ b/src/cfpb/qu/logging.clj
@@ -19,7 +19,6 @@
 
 (defn config
   []
-
   (let [log-file (:log-file env)
         log-level (:log-level env)]
     (log/set-level! log-level)
@@ -71,8 +70,7 @@
     (cond
       (str/blank? (first parts)) "/data.html"
       (= 1 (count parts)) (str uri ".html")
-      :else uri))
-  )
+      :else uri)))
 
 (defn wrap-with-logging
   [handler]

--- a/src/cfpb/qu/middleware/stacktrace.clj
+++ b/src/cfpb/qu/middleware/stacktrace.clj
@@ -1,0 +1,21 @@
+(ns cfpb.qu.middleware.stacktrace
+  "Catch exceptions and render web and log stacktraces for debugging."
+  (:require [cfpb.qu.views :as views]))
+
+(defn- ex-response
+  [req ex]
+  (if-let [accept (get-in req [:headers "accept"])]
+    (cond
+     (re-find #"^json" accept) (views/json-error 500)
+     :else (views/error-html))
+    (views/error-html)))
+
+(defn wrap-stacktrace-web
+  "Wrap a handler such that exceptions are caught and no information
+  is leaked to the user."
+  [handler]
+  (fn [request]
+    (try
+      (handler request)
+      (catch Exception ex
+        (ex-response request ex)))))

--- a/src/cfpb/qu/views.clj
+++ b/src/cfpb/qu/views.clj
@@ -59,6 +59,13 @@
 (defn not-found-html [message]
   (antlers/render-file "templates/404" {:message message}))
 
+(defn error-html
+  ([] (error-html 500))
+  ([status]
+     (-> (response/response (layout-html (antlers/render-file "templates/500" {})))
+         (response/status status)
+         (response/content-type "text/html"))))
+
 (defn- write-csv [data]
   (with-out-str (csv/write-csv *out* data)))
 


### PR DESCRIPTION
In addition, this set a connection and socket timeout on MongoDB
connections of 2 seconds. This can be adjusted via configuration.
