### PR TITLE
Add more configurability to Swagger output

### DIFF
--- a/resources/datasets/hmda/definition.json
+++ b/resources/datasets/hmda/definition.json
@@ -2,7 +2,8 @@
   "info": {
     "url": "http://www.ffiec.gov/hmda/hmdaproducts.htm", 
     "name": "2007-2012 HMDA LAR",
-    "description": "Home Mortgage Disclosure Act Data for the years 2007-2012."
+    "description": "Home Mortgage Disclosure Act Data for the years 2007-2012.",
+    "swagger_description": "LAR data"
   },
   "concepts": {
     "action_taken": {

--- a/src/cfpb/qu/swagger.clj
+++ b/src/cfpb/qu/swagger.clj
@@ -22,13 +22,17 @@
   [req]
   (let [base-url (base-url req)]
     (route/with-base-url base-url
-      (let [datasets (data/get-dataset-names)
+      (let [datasets (data/get-datasets)
+            dataset-descriptions {"hmda" "Operations about mortgage data"}
             dataset-apis (map #(into {} {:path (route/with-base-url base-url
-                                                 (urls/swagger-api-declaration-url :api %))
-                                         :summary (str "Operations about " %)}) datasets)]
+                                                 (urls/swagger-api-declaration-url :api (:name %)))
+                                         :description (str "Operations about "
+                                                           (or (get-in % [:info :swagger_description])
+                                                               (:name %)))}) datasets)]
+        
         (versions
          {:apis (concat [{:path (urls/swagger-api-declaration-url :api "data")
-                          :description "Operations about datasets."}]
+                          :description "Operations about datasets"}]
                         dataset-apis
                         []
                         )})))))


### PR DESCRIPTION
Datasets can specify their description in the Swagger console.

After adding this, `(loader/ez-load-definition "hmda")` needs to be run.
