### PR TITLE
Change the Load Data Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Make sure you have MongoDB started. To load some sample data, run
 ```clojure
 (require 'cfpb.qu.loader)
 (in-ns 'cfpb.qu.loader)
-(ensure-mongo-connection)
+(mongo/connect!)
 (load-dataset "county_taxes")
 (load-dataset "census") ; Takes quite a while to run; can skip.
 (mongo/disconnect!)


### PR DESCRIPTION
I changes the Load Data Section of the ReadMe to be consistent with http://cfpb.github.io/qu/getting-started.html
as there is no function `(ensure-mongo-connection)`
