### PR TITLE
Add a sort before running map reduce

### DIFF
--- a/src/cfpb/qu/data/definition.clj
+++ b/src/cfpb/qu/data/definition.clj
@@ -104,6 +104,14 @@
   [definition slice]
   (apply concat ((juxt dimensions metrics) definition slice)))
 
+(defn indexes
+  "Get the list of indexed fields for a slice."
+  [definition slice]
+  (let [slicedef (get-in definition [:slices slice])]
+    (or (:indexes slicedef)
+        (:index_only slicedef) ; deprecated
+        (:dimensions slicedef))))
+
 ;; (read-definition (io/resource "datasets/integration_test/definition.json"))
 ;; (read-definition (io/resource "datasets/hmda/definition.json"))
 ;; (s/explain DataDefinitionS)

--- a/test/cfpb/qu/test/data/aggregation.clj
+++ b/test/cfpb/qu/test/data/aggregation.clj
@@ -1,0 +1,27 @@
+(ns cfpb.qu.test.data.aggregation
+  (:require [clojure.test :refer :all]
+            [cfpb.qu.data.aggregation :refer :all]))
+
+
+(deftest test-sorting
+  (testing "it sorts by first indexed grouped field"
+    (let [mr (generate-map-reduce* {:dataset "integration_test"
+                                    :from "incomes"
+                                    :to "test1"
+                                    :group [:state_abbr]
+                                    :aggregations {:max_tax_returns ["max" "tax_returns"]}
+                                    :slicedef {:indexes ["state_abbr"]}})]
+
+      (is (= (:sort mr)
+             (array-map "state_abbr" 1))))
+
+
+    (let [mr (generate-map-reduce* {:dataset "integration_test"
+                                    :from "incomes"
+                                    :to "test1"
+                                    :group [:county_abbr :state_abbr]
+                                    :aggregations {:max_tax_returns ["max" "tax_returns"]}
+                                    :slicedef {:indexes ["state_abbr"]}})]
+
+      (is (= (:sort mr)
+             (array-map "state_abbr" 1))))))


### PR DESCRIPTION
Based off [this article](http://edgystuff.tumblr.com/post/54709368492/how-to-speed-up-mongodb-map-reduce-by-20x) and some local tests, this should speed map-reduce.
