### PR TITLE
Fix query building UI in IE8

### DIFF
--- a/resources/static/js/data-api.js
+++ b/resources/static/js/data-api.js
@@ -20,11 +20,14 @@
     
     var action = href + "." + format;
     
-    var formString = _(formVals).pairs()
+    var formString = _(formVals)
+      .chain()
+      .pairs()
       .map(function (pair) {
         return pair[0] + "=" +
           encodeURIComponent(pair[1]).replace(/%20/g,'+');
       })
+      .value()
       .join("<br />&");
 
     $form


### PR DESCRIPTION
IE8 is trying to use its native (non-existent) array methods.

Fixes #163.
