### PR TITLE
Allow keyword or string for database name in mongo auth config

### DIFF
--- a/src/qu/app/options.clj
+++ b/src/qu/app/options.clj
@@ -16,7 +16,7 @@
    :queue-size s/Int})
 
 (def MongoOptionsS
-  (let [database s/Str
+  (let [database (s/either s/Str s/Keyword)
         conn-uri-s {:uri s/Str}
         conn-hosts-s {:hosts [[(s/one s/Str "ip")
                                (s/one s/Int "port")]]}


### PR DESCRIPTION
The current dev configuration was not working b/c it was using keywords for DB names.
