### PR TITLE
Fix validation error; add metrics for stream ops

### DIFF
--- a/src/qu/main.clj
+++ b/src/qu/main.clj
@@ -64,7 +64,7 @@
   (if (:statsd-host env)
     {:provider :statsd
      :host (:statsd-host env)
-     :port (:statsd-port env)}
+     :port (->int (:statsd-port env))}
     {}))
 
 (defn default-options


### PR DESCRIPTION
Fix metrics port so that STATSD_PORT=8125 can be passed from env without validation error; Add metrics collection around stream open/close/cancel
