### PR TITLE
Redact authentication details from logging on startup

### DIFF
--- a/src/qu/app.clj
+++ b/src/qu/app.clj
@@ -56,8 +56,8 @@
   component/Lifecycle
 
   (start [system]
-    (let [system (component/start-system system components)]      
-      (log/info "Started with settings" (str options))
+    (let [system (component/start-system system components)]
+      (log/info "Started with settings" (str (update-in options [:mongo :auth] (fn [_] str "*****"))))
       system))
   
   (stop [system]


### PR DESCRIPTION
When running with mongo auth details in the config file, passwords would be output to the log file. This fixes that problem.
