### PR TITLE
Enable 'allowDiskUse' for aggregations. Without this, errors ensue

### DIFF
--- a/src/qu/cache.clj
+++ b/src/qu/cache.clj
@@ -95,7 +95,7 @@ the same backing database have access to the same data."
         to-collection (:to aggmap)]
     (log/info "Running aggregation query:" source-database agg-query)
     (with-db source-database
-      (coll/aggregate (:from aggmap) agg-query))))
+      (mongo/command (sorted-map :aggregate (:from aggmap) :pipeline agg-query :allowDiskUse true)))))
 
 (defn touch-cache
   "Sets the created value for a query to now."


### PR DESCRIPTION
allowDiskUse is required for aggregations that can't be completed completely in memory. This will be a common occurrence on large data sets.

Without this, we experience errors such as: `exception: Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in.`

Need to use `mongo/command` directly as the `aggregate` api does not expose options

`sorted-map` is required because mongo commands require an object whose first key is the command to be executed.
