### PR TITLE
Fix 404 error for lein in vagrant provisioning

### DIFF
--- a/doc/manifests/vagrant.pp
+++ b/doc/manifests/vagrant.pp
@@ -41,7 +41,7 @@ package { "java-1.7.0-openjdk":
 }
 
 exec { 'install leiningen':
-  command => "/usr/bin/curl -sL https://raw.github.com/technomancy/leiningen/stable/bin/lein > /usr/bin/lein",
+  command => "/usr/bin/curl -sL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > /usr/bin/lein",
   creates => "/usr/bin/lein",
 }
 


### PR DESCRIPTION
Currently, vagrant provision produces the following content for /usr/bin/lein:

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
</p>
</body></html>
```
