### PR TITLE
Enable 'allowDiskUse' for aggregations when loading new data

### DIFF
--- a/src/qu/loader.clj
+++ b/src/qu/loader.clj
@@ -300,7 +300,7 @@ transform that data into the form we want."
         zip-fn (field-zip-fn slicedef)
         rename-map (reduce (fn [acc field]
                              (merge acc {(zip-fn field) field})) {} fields)
-        agg-results (coll/aggregate from-collection agg-query)]
+        agg-results (mongo/command (sorted-map :aggregate from-collection :pipeline agg-query :allowDiskUse true))]
     (log/info "Aggregation for " slice agg-query)
     (log/info "Results of aggregation for" slice agg-results)
     (coll/update slice {} {"$rename" rename-map} :multi true)))


### PR DESCRIPTION
Similar fix to #205.  This change addresses the following error when loading new data:

`exception: Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in.`
