### PR TITLE
Attempt to address csv output bug with flush command

### DIFF
--- a/src/qu/views.clj
+++ b/src/qu/views.clj
@@ -50,7 +50,7 @@
 
 (defn- write-csv [data]
   (with-out-str (csv/write-csv *out* data))
-  (flush)
+  (flush))
 
 (defn slice-html
   [view-map]


### PR DESCRIPTION
This is an attempt to address #209, which describes how some CSV exports have an incorrect number of records.

It was noticed that when an export is incorrect, the last line is incomplete.  Below is a sample of the last two lines:

```
"98.18000030517578","","9875","4.159999847412109","3280","4000","160","58300","73","South Carolina","SC","0028728","22-3887207","Ginnie Mae (GNMA)","One-to-four family dwelling (other than manufactured housing)","Not applicable","Owner-occupied as a principal dwelling","Greenville, Mauldin, Easley - SC","VA-guaranteed","Refinancing","Secured by a first lien","Not a HOEPA loan","","","","","Pickens County","Female","","","","","White","Not Hispanic or Latino","0106.00","2011","0","Male","","","","","White","Not Hispanic or Latino","Department of Housing and Urban Development","HUD","Loan originated"
"144.08999633789062","01.75","6651","9.739999771118164","2365","2649","217","73300","92","New Jersey","NJ","0027536","22-3887207","Ginnie Mae (GNMA)","One-to-four family dwelling (other than manufactured housing)","Not applicable","Owner-occupied as a principal dwelling","Allentown, Bethlehem, Easton - PA, NJ","VA-guar
```

In the event that this is a buffering issue, this PR adds a `(flush)` comand after writing the csv.  I was unable to recreate the issue in my development environment, so I'm not sure this will fix the issue.
