### PR TITLE
Fixed mistake in download instructions

### DIFF
--- a/doc/vagrant.md
+++ b/doc/vagrant.md
@@ -7,7 +7,7 @@ With Vagrant, everything you need for Qu should be isolated on a virtual machine
 After downloading the code via git like so:
 
 ```sh
-git checkout git@github.com:cfpb/qu.git
+git clone git@github.com:cfpb/qu.git
 cd qu
 ```
 


### PR DESCRIPTION
Download example should use git clone, not checkout
