### PR TITLE
Correct compression titles for derived slices

### DIFF
--- a/src/qu/loader.clj
+++ b/src/qu/loader.clj
@@ -299,10 +299,11 @@ transform that data into the form we want."
         fields (data/slice-columns slicedef)
         zip-fn (field-zip-fn slicedef)
         rename-map (reduce (fn [acc field]
-                             (merge acc {(zip-fn field) field})) {} fields)
+                             (merge acc {field (zip-fn field)})) {} fields)
         agg-results (mongo/command (sorted-map :aggregate from-collection :pipeline agg-query :allowDiskUse true))]
     (log/info "Aggregation for " slice agg-query)
     (log/info "Results of aggregation for" slice agg-results)
+    ;; Convert field names to compressed fields
     (coll/update slice {} {"$rename" rename-map} :multi true)))
 
 (defmethod load-slice :default


### PR DESCRIPTION
Queries on derived slices always return zero results.  The reason is because the collections are using full table names rather than the compressed table names.  When the qu API generates a query for a request, the compressed table names are used, hence the empty result.

The root of the issue is that the rename-map field swaps the order of the key and value.  for example, (:ac "full name") instead of ("full name" :ac).  Swapping the values so the full name is on the left resolves the issue.

TODO: create a unit test to catch this issue
