### PR TITLE
update roadmap and getting started docs

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -10,15 +10,11 @@ layout: default
 In order to install and use _qu_, you need the following languages and
 tools installed:
 
-* [Java][]
-* [Node.js][]
-* [Leiningen][]
-* [MongoDB][]
+* [Java](http://www.java.com/en/)
+* [Node.js](http://nodejs.org/)
+* [Leiningen](http://leiningen.org/)
+* [MongoDB 2.6+](http://www.mongodb.org/)
 
-[Java]: http://www.java.com/en/
-[Node.js]: http://nodejs.org/
-[Leiningen]: http://leiningen.org/
-[MongoDB]: http://www.mongodb.org/
 
 ### Setup
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -4,19 +4,12 @@ published: true
 layout: default
 ---
 
-This roadmap is provisional and pre-decisional. It may change at any time, but reflects current plans.
+This roadmap is provisional and pre-decisional.
 
-## Recent Changes
-
-* Turned Qu into a library that can be used to create new data APIs.
-  * Added a [Leiningen template](https://github.com/qu-platform/lein-template) for creating new Qu instances.
-* Made HTML templates customizable per API.
-
-## Near Future
+## Possibilities
 
 * Allow for pluggable data sources
   * MongoDB
-    - MongoDB 2.6 - move back to aggregation framework
     - MongoDB with compression vs without compression
   * Postgres
   * In-memory
@@ -28,9 +21,6 @@ This roadmap is provisional and pre-decisional. It may change at any time, but r
   * All of these are currently supported, but we want to make them pluggable.
 * Have VMs available for download to try out Qu.
 * Create a publicly available deployment strategy guide.
-
-## Next Steps
-
 * Data loading improvements
   * Simplify data definition format
   * Allow for incremental data loads
@@ -40,9 +30,6 @@ This roadmap is provisional and pre-decisional. It may change at any time, but r
   * Track usage and hot queries
   * Add new datasets through dashboard
   * Identify useful indexes based on query logs
-
-## Possibilities
-
 * API keys
   * Rate limiting
   * Data access controls


### PR DESCRIPTION
roadmap: Move items out of "near future" and "next steps" to "possibilities" section to reflect current state of Qu maintenance.

getting_started: Indicate requirement for MongoDB 2.6+