### PR TITLE
Validate $page argument

### DIFF
--- a/src/qu/query/validation.clj
+++ b/src/qu/query/validation.clj
@@ -144,6 +144,15 @@
         (catch NumberFormatException e
           (add-error query clause "Please use an integer."))))))
 
+(defn- validate-positive-integer
+  [query clause]
+  (let [query (validate-integer query clause)
+        val (->int (clause query) 1)]
+    (if (>= 0 val)
+      (add-error query clause "Should be positive")
+      query)))
+
+
 (defn- validate-max-offset
   [query]
   (let [offset (->int (:offset query) 0)]
@@ -166,6 +175,11 @@
   [query]
   (validate-integer query :offset))
 
+(defn- validate-page
+  [query]
+  (validate-positive-integer query :page))
+
+
 (defn validate
   "Check the query for any errors."
   [query]
@@ -178,5 +192,6 @@
         validate-order-by
         validate-limit
         validate-offset
+        validate-page
         validate-max-offset)
     query))

--- a/test/qu/test/query/validation.clj
+++ b/test/qu/test/query/validation.clj
@@ -72,6 +72,12 @@
          
     (testing "it errors if offset is not an integer string"
       (does-contain (errors (q :offset "ten")) :offset)
-      (does-not-contain (errors (q :offset "10")) :offset))))
+      (does-not-contain (errors (q :offset "10")) :offset))
+
+    (testing "it errors if page is not a positive integer string"
+      (does-contain (errors (q :page "ten")) :page)
+      (does-contain (errors (q :page "-1")) :page)
+      (does-contain (errors (q :page "0")) :page)
+      (does-not-contain (errors (q :page "10")) :page))))
 
 ;; (run-tests)


### PR DESCRIPTION
Fixing a bug when clicking "Prev" can cause a Server Error.

P.S. I am not sure why we return a map in lines 239-241 from "exists?". From Liberator documentation it seems that "exists?" should return true/false. Wouldn't this map always be considered as "true"?