### PR TITLE
Display number of elements specified in "limit" field

### DIFF
--- a/src/qu/query/validation.clj
+++ b/src/qu/query/validation.clj
@@ -13,7 +13,7 @@
 
 (defn valid-field? [{:keys [metadata slice]} field]
   (let [fields (->> (slice-columns (get-in metadata [:slices (keyword slice)]))
-                     (map name)                     
+                     (map name)
                      set)
         fields (conj fields "_id")]
     (contains? fields field)))
@@ -152,6 +152,14 @@
       (add-error query clause "Should be positive")
       query)))
 
+(defn- validate-non-negative-integer
+  [query clause]
+  (let [query (validate-integer query clause)
+        val (->int (clause query) 0)]
+    (if (> 0 val)
+      (add-error query clause "Should be non-negative")
+      query)))
+
 
 (defn- validate-max-offset
   [query]
@@ -160,16 +168,19 @@
       (add-error query :offset (str "The maximum offset is 10,000."))
       query)))
 
-(defn- validate-max-limit
+(defn validate-max-limit
   [query max]
   (let [limit (->int (:limit query) 0)]
     (if (> limit max)
-      (add-error query :limit (str "The maximum limit is " max "."))
+      (add-error query :limit (str "The maximum HTML limit is "
+                                   max
+                                   ". The entire result set is available in CSV, JSON and XML formats."))
       query)))
 
 (defn- validate-limit
   [query]
-  (validate-integer query :limit))
+  (validate-non-negative-integer query :limit))
+
 
 (defn- validate-offset
   [query]

--- a/src/qu/templates/slice.mustache
+++ b/src/qu/templates/slice.mustache
@@ -134,11 +134,6 @@
 {{#has-data?}}
 <section class="bottom-pad">
   <h2>Query Results ({{start}}-{{end}} of {{total}})</h2>
-  {{#has-more-data?}}
-  <div class="alert">
-    Only the first 100 results are shown. The entire result set is available in CSV, JSON, and XML formats.
-  </div>
-  {{/has-more-data?}}
 
 
   {{> qu/templates/pagination}}

--- a/src/qu/views.clj
+++ b/src/qu/views.clj
@@ -297,7 +297,6 @@
                 dec)
         total (get-in resource [:properties :total])
         has-data? (>= (- end start) 0)
-        has-more-data? (> data-size 100)
         pagination (create-pagination resource)
         computing (get-in resource [:properties :computing])
         computing? (->bool computing)
@@ -319,7 +318,6 @@
                           :total total
                           :pagination pagination
                           :has-data? has-data?
-                          :has-more-data? has-more-data?
                           :computing? computing?
                           :computing computing
                           :data data})]

--- a/test/qu/test/query/validation.clj
+++ b/test/qu/test/query/validation.clj
@@ -16,7 +16,8 @@
                     :slice :county_taxes
                     :metadata metadata}
                    query))
-        errors (comp :errors v/validate)]
+        errors (comp :errors v/validate)
+        limit-errors (fn [query] (:errors (v/validate-max-limit query 100)))]
 
     (testing "it errors when it cannot parse SELECT"
       (does-contain (errors (q :select "what what")) :select))
@@ -66,10 +67,14 @@
       (does-contain (errors (q :limit "ten")) :limit)
       (does-not-contain (errors (q :limit "10")) :limit))
 
-    (testing "it does not error if limit is greater than 1000"
-      (does-not-contain (errors (q :limit "1001"))
-                        {:limit ["The maximum limit is 1000."]}))
-         
+    (testing "it errors if limit is greater than 100"
+      (does-contain (limit-errors (q :limit "101")) :limit)
+      (does-not-contain (limit-errors (q :limit "100")) :limit))
+
+    (testing "it errors if limit is less than 0"
+      (does-contain (errors (q :limit "-1")) :limit)
+      (does-not-contain (errors (q :limit "0")) :limit))
+
     (testing "it errors if offset is not an integer string"
       (does-contain (errors (q :offset "ten")) :offset)
       (does-not-contain (errors (q :offset "10")) :offset))


### PR DESCRIPTION
Instead of displaying up to 100 records now displays up the number of records provided in "limit" field.