### PR TITLE
Shrinkwrap front-end dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save=true
+save-exact=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.12 - 2016-04-08
+
+ - Lock down front-end dependencies using `npm shrinkwrap` (c962a27)
+
 ## v1.1.11 - 2016-02-08
 
  - Validate `$page` argument (a44a85b)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,4 @@
+{
+  "name": "data-api",
+  "version": "1.1.0"
+}


### PR DESCRIPTION
Funny story: there aren't any npm front-end dependencies. But it's still good to have the shrinkwrap file in the event we add some in the future.

@marcesher 