### PR TITLE
Update nss so that dependencies can be retrieved

### DIFF
--- a/doc/manifests/vagrant.pp
+++ b/doc/manifests/vagrant.pp
@@ -69,6 +69,10 @@ file { "/usr/bin/lein":
   require => Exec["install leiningen"],
 }
 
+package{"nss":
+  ensure => "latest",
+}
+
 exec { 'install bower':
   timeout => 1800,
   command => "/usr/bin/npm install -g bower",


### PR DESCRIPTION
Otherwise get "Could not transfer artifact ...
java.security.ProviderException: java.security.KeyException" errors

@m3brown @marcesher 