### PR TITLE
Disable limit for HTML and force page size 100

### DIFF
--- a/resources/static/js/data-api.js
+++ b/resources/static/js/data-api.js
@@ -41,9 +41,13 @@
       if (format === 'jsonp') {
           callback_container.removeClass('hide');
           $("#field-callback").prop('disabled', '');
+      } else if (format === 'html') {
+          $('#field-limit').val(100);
+          $('#field-limit').attr('disabled', 'disabled');
       } else {
           callback_container.addClass('hide');
           $("#field-callback").val('').prop('disabled', 'disabled');
+          $('#field-limit').removeAttr('disabled');
       }
     }
   };

--- a/src/qu/views.clj
+++ b/src/qu/views.clj
@@ -204,7 +204,7 @@
      {:key "where"    :label "Where"            :bootstrap_span 12     :tooltip_title "Where Clause"     :tooltip_body "Filters the result set via a subset of SQL syntax. Supports standard comparison and boolean operators. See the API documentation for more details." }
      {:key "group"    :label "Group By"         :bootstrap_span 6      :tooltip_title "Group By Clause"  :tooltip_body "As in SQL, projects rows with common values into a smaller set. Supports the aggregation functions SUM, MIN, MAX, and COUNT. Requires a select clause."}
      {:key "orderBy"  :label "Order By"         :bootstrap_span 6      :tooltip_title "Order By Clause"  :tooltip_body "A comma-delimited list of fields used to sort the result set. As with SQL, use DESC for descending order. If blank, the order will be consistent but unspecified."}
-     {:key "limit"    :label "Limit"            :bootstrap_span 1      :tooltip_title "Limit Clause"     :tooltip_body "The maximum number of results to return. Defaults to 100. HTML returns are limited to 10,000 results. Other formats are not limited."}
+     {:key "limit"    :label "Limit"            :bootstrap_span 1      :tooltip_title "Limit Clause"     :tooltip_body "The maximum number of results to return. The HTML limit is fixed at 10,000, with 100 results shown per page. Other formats are not limited."}
      {:key "offset"   :label "Offset"           :bootstrap_span 1      :tooltip_title "Offset Clause"    :tooltip_body "Zero-based offset to start the result set from. Defaults to 0."}
      ])
 


### PR DESCRIPTION
The way that limit serves as page size for HTML is confusing and not useful. Disable use of limit for HTML as a temporary solution.